### PR TITLE
[#1] Adds Dependency for pg.utils

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "pg.utils"]
-	path = pg.utils
-	url = https://github.com/KadVenku/pg.utils.git

--- a/pg.mtd.sln
+++ b/pg.mtd.sln
@@ -7,8 +7,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "pg.mtd", "pg.mtd\pg.mtd.csp
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "pg.mtd.test", "pg.mtd.test\pg.mtd.test.csproj", "{F721F6E1-B388-42E0-AF79-CB02A0F508F5}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "pg.util", "pg.utils\pg.util\pg.util.csproj", "{BA180F03-EC10-4E7D-8638-39D18D11640C}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/pg.mtd.test/builder/MtdImageTableRecordBuilderUnitTest.cs
+++ b/pg.mtd.test/builder/MtdImageTableRecordBuilderUnitTest.cs
@@ -15,7 +15,7 @@ namespace pg.mtd.test.builder
     public class MtdImageTableRecordBuilderUnitTest
     {
         private const int MTD_IMAGE_TABLE_RECORD_SIZE = sizeof(byte) * 64 + sizeof(uint) * 4 + sizeof(bool);
-        private const string MTD_RECORD = "testdata\\mtd_single_record.mtd";
+        private readonly string MTD_RECORD = Path.Combine("testdata", "mtd_single_record.mtd");
 
         [DataRow("ValidName1", 1u, 1u, 1u, 1u, true)]
         [DataRow("ValidName1", 1u, 1u, 1u, 1u, false)]
@@ -30,7 +30,8 @@ namespace pg.mtd.test.builder
         [DataRow("ValidName6", 6u, 6u, 6u, 6u, true)]
         [DataRow("ValidName6", 6u, 6u, 6u, 6u, false)]
         [DataTestMethod]
-        public void MtdImageTableRecordBuilderBuildMtdImageTableRecordTest(string name, uint posX, uint posY, uint exX, uint exY, bool alpha)
+        public void MtdImageTableRecordBuilderBuildMtdImageTableRecordTest(string name, uint posX, uint posY, uint exX,
+            uint exY, bool alpha)
         {
             List<byte> inputAsBytes = new List<byte>();
             byte[] n = Encoding.ASCII.GetBytes(name);
@@ -54,7 +55,15 @@ namespace pg.mtd.test.builder
             byte[] inAsByteArray = inputAsBytes.ToArray();
 
             MtdImageTableRecordBuilder builder = new MtdImageTableRecordBuilder();
-            MtdImageTableRecordAttribute attribute = new MtdImageTableRecordAttribute { Name = name, XPosition = posX, YPosition = posY, XExtend = exX, YExtend = exY, Alpha = alpha };
+            MtdImageTableRecordAttribute attribute = new MtdImageTableRecordAttribute
+            {
+                Name = name,
+                XPosition = posX,
+                YPosition = posY,
+                XExtend = exX,
+                YExtend = exY,
+                Alpha = alpha
+            };
             MtdImageTableRecord record = builder.Build(attribute);
             MtdImageTableRecord recordFromBytes = builder.Build(inAsByteArray);
             byte[] bytesFromAttributes = record.GetBytes();
@@ -67,6 +76,7 @@ namespace pg.mtd.test.builder
             {
                 Assert.AreEqual(bytesFromAttributes[i], inAsByteArray[i]);
             }
+
             for (int i = 0; i < bytesFromBytes.Length; i++)
             {
                 Assert.AreEqual(bytesFromBytes[i], inAsByteArray[i]);

--- a/pg.mtd/builder/MtdHeaderBuilder.cs
+++ b/pg.mtd/builder/MtdHeaderBuilder.cs
@@ -6,7 +6,7 @@ using pg.util.interfaces;
 
 namespace pg.mtd.builder
 {
-    internal sealed class MtdHeaderBuilder : IBinaryFileBuilder<MtdHeader,MtdHeaderAttribute>
+    internal sealed class MtdHeaderBuilder : IBinaryFileBuilder<MtdHeader, MtdHeaderAttribute>
     {
         public MtdHeader Build(byte[] bytes)
         {
@@ -14,10 +14,13 @@ namespace pg.mtd.builder
             {
                 throw new ArgumentNullException($"Expected byte array \'{nameof(bytes)}\', got \'null\' instead.");
             }
-            if (bytes.Length != MtdHeader.SIZE)
+
+            if (bytes.Length != new MtdHeader().Size())
             {
-                throw new InvalidByteArrayException($"The byte stream provided does not match the size of a valid \'{nameof(MtdHeader)}\'. Expected {MtdHeader.SIZE} bytes, but received {bytes.Length} bytes.");
+                throw new InvalidByteArrayException(
+                    $"The byte stream provided does not match the size of a valid \'{nameof(MtdHeader)}\'. Expected {new MtdHeader().Size()} bytes, but received {bytes.Length} bytes.");
             }
+
             MtdHeaderAttributeBuilder mtdHeaderAttributeBuilder = new MtdHeaderAttributeBuilder();
             MtdHeaderAttribute attribute = mtdHeaderAttributeBuilder.Build(bytes);
             return Build(attribute);

--- a/pg.mtd/builder/MtdImageTableBuilder.cs
+++ b/pg.mtd/builder/MtdImageTableBuilder.cs
@@ -19,10 +19,13 @@ namespace pg.mtd.builder
             {
                 throw new ArgumentNullException($"Expected byte array \'{nameof(bytes)}\', got \'null\' instead.");
             }
-            if (bytes.Length % MtdImageTableRecord.SIZE != 0)
+
+            if (bytes.Length % new MtdImageTableRecord().Size() != 0)
             {
-                throw new InvalidByteArrayException($"The provided byte array does not contain a valid number of entries. Expected length: {(bytes.Length/MtdImageTableRecord.SIZE + 1) * MtdImageTableRecord.SIZE} bytes; actual length {bytes.Length} bytes.");
+                throw new InvalidByteArrayException(
+                    $"The provided byte array does not contain a valid number of entries. Expected length: {(bytes.Length / new MtdImageTableRecord().Size() + 1) * new MtdImageTableRecord().Size()} bytes; actual length {bytes.Length} bytes.");
             }
+
             MtdImageTableAttributeBuilder builder = new MtdImageTableAttributeBuilder();
             MtdImageTableAttribute attribute = builder.Build(bytes);
             return Build(attribute);
@@ -34,6 +37,7 @@ namespace pg.mtd.builder
             {
                 throw new AttributeNullException(nameof(attribute));
             }
+
             return new MtdImageTable(attribute);
         }
     }

--- a/pg.mtd/builder/MtdImageTableRecordBuilder.cs
+++ b/pg.mtd/builder/MtdImageTableRecordBuilder.cs
@@ -5,11 +5,13 @@ using pg.mtd.exceptions;
 using pg.mtd.typedef;
 using pg.util.exceptions;
 using pg.util.interfaces;
+
 [assembly: InternalsVisibleTo("pg.mtd.test")]
 
 namespace pg.mtd.builder
 {
-    internal sealed class MtdImageTableRecordBuilder : IBinaryFileBuilder<MtdImageTableRecord, MtdImageTableRecordAttribute>
+    internal sealed class
+        MtdImageTableRecordBuilder : IBinaryFileBuilder<MtdImageTableRecord, MtdImageTableRecordAttribute>
     {
         public MtdImageTableRecord Build(byte[] bytes)
         {
@@ -17,10 +19,13 @@ namespace pg.mtd.builder
             {
                 throw new ArgumentNullException($"Expected byte array \'{nameof(bytes)}\', got \'null\' instead.");
             }
-            if (bytes.Length != MtdImageTableRecord.SIZE)
+
+            if (bytes.Length != new MtdImageTableRecord().Size())
             {
-                throw new InvalidByteArrayException($"The byte stream provided does not match the size of a valid \'{nameof(MtdImageTableRecord)}\'. Expected {MtdImageTableRecord.SIZE} bytes, but received {bytes.Length}.");
+                throw new InvalidByteArrayException(
+                    $"The byte stream provided does not match the size of a valid \'{nameof(MtdImageTableRecord)}\'. Expected {new MtdImageTableRecord().Size()} bytes, but received {bytes.Length}.");
             }
+
             MtdImageTableRecordAttributeBuilder attributeBuilder = new MtdImageTableRecordAttributeBuilder();
             return Build(attributeBuilder.Build(bytes));
         }
@@ -29,8 +34,10 @@ namespace pg.mtd.builder
         {
             if (attribute == null)
             {
-                throw new AttributeNullException($"Building an instance of \'{nameof(MtdImageTableRecord)}\' requires a non-null argument of type \'{nameof(MtdImageTableRecordAttribute)}\'.");
+                throw new AttributeNullException(
+                    $"Building an instance of \'{nameof(MtdImageTableRecord)}\' requires a non-null argument of type \'{nameof(MtdImageTableRecordAttribute)}\'.");
             }
+
             return new MtdImageTableRecord(attribute);
         }
     }

--- a/pg.mtd/builder/attributes/MtdFileAttribute.cs
+++ b/pg.mtd/builder/attributes/MtdFileAttribute.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using pg.util.interfaces;
+
 [assembly: InternalsVisibleTo("pg.mtd.test")]
 
 namespace pg.mtd.builder.attributes

--- a/pg.mtd/builder/attributes/MtdHeaderAttribute.cs
+++ b/pg.mtd/builder/attributes/MtdHeaderAttribute.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using pg.util.interfaces;
+
 [assembly: InternalsVisibleTo("pg.mtd.test")]
 
 namespace pg.mtd.builder.attributes

--- a/pg.mtd/builder/attributes/MtdHeaderAttributeBuilder.cs
+++ b/pg.mtd/builder/attributes/MtdHeaderAttributeBuilder.cs
@@ -11,6 +11,7 @@ namespace pg.mtd.builder.attributes
             {
                 throw new ArgumentNullException($"Expected byte array \'{nameof(bytes)}\', got \'null\' instead.");
             }
+
             return new MtdHeaderAttribute {RecordCount = BitConverter.ToUInt32(bytes, 0)};
         }
     }

--- a/pg.mtd/builder/attributes/MtdImageTableAttribute.cs
+++ b/pg.mtd/builder/attributes/MtdImageTableAttribute.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using pg.util.interfaces;
+
 [assembly: InternalsVisibleTo("pg.mtd.test")]
 
 namespace pg.mtd.builder.attributes

--- a/pg.mtd/builder/attributes/MtdImageTableAttributeBuilder.cs
+++ b/pg.mtd/builder/attributes/MtdImageTableAttributeBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using pg.mtd.typedef;
 using pg.util.interfaces;
+
 [assembly: InternalsVisibleTo("pg.mtd.test")]
 
 namespace pg.mtd.builder.attributes
@@ -15,16 +16,19 @@ namespace pg.mtd.builder.attributes
             {
                 throw new ArgumentNullException($"Expected byte array \'{nameof(bytes)}\', got \'null\' instead.");
             }
+
             MtdImageTableAttribute attribute = new MtdImageTableAttribute();
             MtdImageTableRecordAttributeBuilder attributeBuilder = new MtdImageTableRecordAttributeBuilder();
             int currentByteIndex = 0;
-            for (int recordIndex = 0; recordIndex < bytes.Length / MtdImageTableRecord.SIZE; recordIndex++)
+            for (int recordIndex = 0; recordIndex < bytes.Length / new MtdImageTableRecord().Size(); recordIndex++)
             {
-                byte[] b = new List<byte>(bytes).GetRange(currentByteIndex, MtdImageTableRecord.SIZE).ToArray();
+                byte[] b = new List<byte>(bytes)
+                    .GetRange(currentByteIndex, Convert.ToInt32(new MtdImageTableRecord().Size())).ToArray();
                 MtdImageTableRecordAttribute a = attributeBuilder.Build(b);
                 attribute.Images.Add(a);
-                currentByteIndex += MtdImageTableRecord.SIZE;
+                currentByteIndex += Convert.ToInt32(new MtdImageTableRecord().Size());
             }
+
             return attribute;
         }
     }

--- a/pg.mtd/builder/attributes/MtdImageTableRecordAttribute.cs
+++ b/pg.mtd/builder/attributes/MtdImageTableRecordAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System.Runtime.CompilerServices;
 using pg.util.interfaces;
+
 [assembly: InternalsVisibleTo("pg.mtd.test")]
 
 namespace pg.mtd.builder.attributes

--- a/pg.mtd/builder/attributes/MtdImageTableRecordAttributeBuilder.cs
+++ b/pg.mtd/builder/attributes/MtdImageTableRecordAttributeBuilder.cs
@@ -4,6 +4,7 @@ using System.Text;
 using pg.mtd.exceptions;
 using pg.mtd.typedef;
 using pg.util.interfaces;
+
 [assembly: InternalsVisibleTo("pg.mtd.test")]
 
 namespace pg.mtd.builder.attributes
@@ -24,10 +25,13 @@ namespace pg.mtd.builder.attributes
             {
                 throw new ArgumentNullException($"Expected byte array \'{nameof(bytes)}\', got \'null\' instead.");
             }
-            if (bytes.Length != MtdImageTableRecord.SIZE)
+
+            if (bytes.Length != new MtdImageTableRecord().Size())
             {
-                throw new InvalidByteArrayException($"The byte stream provided does not match the size of a valid \'{nameof(MtdImageTableRecord)}\'. Expected {MtdImageTableRecord.SIZE} bytes, but received {bytes.Length}.");
+                throw new InvalidByteArrayException(
+                    $"The byte stream provided does not match the size of a valid \'{nameof(MtdImageTableRecord)}\'. Expected {new MtdImageTableRecord().Size()} bytes, but received {bytes.Length}.");
             }
+
             string paddedName = Encoding.ASCII.GetString(bytes, _C_ICON_NAME_OFFSET, _C_ICON_NAME_SIZE);
             string name = Unpad(paddedName);
             uint posX = BitConverter.ToUInt32(bytes, _C_POSITION_X_OFFSET);
@@ -35,20 +39,29 @@ namespace pg.mtd.builder.attributes
             uint exX = BitConverter.ToUInt32(bytes, _C_EXTENSION_X_OFFSET);
             uint exY = BitConverter.ToUInt32(bytes, _C_EXTENSION_Y_OFFSET);
             bool alpha = BitConverter.ToBoolean(bytes, _C_ALPHA_OFFSET);
-            return new MtdImageTableRecordAttribute() {Name = name, XPosition = posX, YPosition = posY, XExtend = exX, YExtend = exY, Alpha = alpha};
+            return new MtdImageTableRecordAttribute()
+            {
+                Name = name,
+                XPosition = posX,
+                YPosition = posY,
+                XExtend = exX,
+                YExtend = exY,
+                Alpha = alpha
+            };
         }
 
         private static string Unpad(string paddedName)
         {
-            string unpaddedName = "";
+            StringBuilder builder = new StringBuilder();
             foreach (char c in paddedName)
             {
                 if (c != '\0')
                 {
-                    unpaddedName += c;
+                    builder.Append(c);
                 }
             }
-            return unpaddedName;
+
+            return builder.ToString();
         }
     }
 }

--- a/pg.mtd/pg.mtd.csproj
+++ b/pg.mtd/pg.mtd.csproj
@@ -1,16 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Lukas Grünwald</Authors>
     <Company />
-    <Copyright>2019 Lukas Grünwald</Copyright>
+    <Copyright>2019 - Lukas Grünwald</Copyright>
     <SignAssembly>false</SignAssembly>
+    <Title>pg.mtd</Title>
+    <PackageProjectUrl>https://github.com/KadVenku/pg.mtd</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/KadVenku/pg.mtd</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>petroglyph, alamo, glyphx</PackageTags>
+    <PackageReleaseNotes>Initial Release</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\pg.utils\pg.util\pg.util.csproj" />
+    <PackageReference Include="pg.util" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/pg.mtd/typedef/MtdFile.cs
+++ b/pg.mtd/typedef/MtdFile.cs
@@ -4,6 +4,7 @@ using System.Runtime.CompilerServices;
 using pg.mtd.builder;
 using pg.mtd.builder.attributes;
 using pg.util.interfaces;
+
 [assembly: InternalsVisibleTo("pg.mtd.test")]
 
 namespace pg.mtd.typedef
@@ -24,10 +25,13 @@ namespace pg.mtd.typedef
             }
             else
             {
-                mtdHeaderBuilder.Build(new MtdHeaderAttribute() {RecordCount = Convert.ToUInt32(attribute.ImageTableAttribute.Images.Count)});
+                mtdHeaderBuilder.Build(new MtdHeaderAttribute()
+                {
+                    RecordCount = Convert.ToUInt32(attribute.ImageTableAttribute.Images.Count)
+                });
             }
         }
-        
+
         public byte[] GetBytes()
         {
             List<byte> bytes = new List<byte>();

--- a/pg.mtd/typedef/MtdHeader.cs
+++ b/pg.mtd/typedef/MtdHeader.cs
@@ -2,16 +2,16 @@
 using System.Runtime.CompilerServices;
 using pg.mtd.builder.attributes;
 using pg.util.interfaces;
+
 [assembly: InternalsVisibleTo("pg.mtd.test")]
 
 namespace pg.mtd.typedef
 {
-    internal sealed class MtdHeader : IBinaryFile
+    internal sealed class MtdHeader : IBinaryFile, ISizeable
     {
-        public static readonly int SIZE = sizeof(uint);
         /*
-         * No builder requred.
-         * Generating the MtdFile needs to automatically generate a headr based on the data contained.
+         * No builder required.
+         * Generating the MtdFile needs to automatically generate a header based on the data contained.
          */
         private readonly uint _recordCount;
 
@@ -19,10 +19,20 @@ namespace pg.mtd.typedef
         {
             _recordCount = attribute.RecordCount;
         }
-        
+
+        internal MtdHeader()
+        {
+            _recordCount = 0;
+        }
+
         public byte[] GetBytes()
         {
             return BitConverter.GetBytes(_recordCount);
+        }
+
+        public uint Size()
+        {
+            return sizeof(uint);
         }
     }
 }

--- a/pg.mtd/typedef/MtdImageTable.cs
+++ b/pg.mtd/typedef/MtdImageTable.cs
@@ -3,11 +3,12 @@ using System.Runtime.CompilerServices;
 using pg.mtd.builder;
 using pg.mtd.builder.attributes;
 using pg.util.interfaces;
+
 [assembly: InternalsVisibleTo("pg.mtd.test")]
 
 namespace pg.mtd.typedef
 {
-    internal sealed class MtdImageTable : IBinaryFile
+    internal sealed class MtdImageTable : IBinaryFile, ISizeable
     {
         private readonly List<MtdImageTableRecord> _mtdImageTableRecords = new List<MtdImageTableRecord>();
 
@@ -30,6 +31,11 @@ namespace pg.mtd.typedef
             }
 
             return bytes.ToArray();
+        }
+
+        public uint Size()
+        {
+            throw new System.NotImplementedException();
         }
     }
 }

--- a/pg.mtd/typedef/MtdImageTableRecord.cs
+++ b/pg.mtd/typedef/MtdImageTableRecord.cs
@@ -5,14 +5,13 @@ using System.Text;
 using pg.mtd.builder.attributes;
 using pg.mtd.exceptions;
 using pg.util.interfaces;
+
 [assembly: InternalsVisibleTo("pg.mtd.test")]
 
 namespace pg.mtd.typedef
 {
-    internal sealed class MtdImageTableRecord : IBinaryFile
+    internal sealed class MtdImageTableRecord : IBinaryFile, ISizeable
     {
-        public const int SIZE = 81;
-
         private const int _C_BNAME_MAX_LENGTH = 64;
         private readonly string _name;
         private readonly uint _xPosition;
@@ -43,6 +42,16 @@ namespace pg.mtd.typedef
             _alpha = attribute.Alpha;
         }
 
+        internal MtdImageTableRecord()
+        {
+            _name = string.Empty;
+            _xPosition = 0;
+            _yPosition = 0;
+            _xExtend = 0;
+            _yExtend = 0;
+            _alpha = false;
+        }
+
         private IEnumerable<byte> GetBName()
         {
             byte[] bytes = new byte[_C_BNAME_MAX_LENGTH];
@@ -50,16 +59,25 @@ namespace pg.mtd.typedef
             {
                 bytes[i] = 0;
             }
+
             byte[] unpaddedName = Encoding.ASCII.GetBytes(_name);
             if (unpaddedName.Length > _C_BNAME_MAX_LENGTH)
             {
-                throw new InvalidIconNameException($"An MTD-element's name may only be {_C_BNAME_MAX_LENGTH} bytes long. The element \'{_name}\' is {unpaddedName.Length} bytes long and exceeds the limit by {unpaddedName.Length - _C_BNAME_MAX_LENGTH}.");
+                throw new InvalidIconNameException(
+                    $"An MTD-element's name may only be {_C_BNAME_MAX_LENGTH} bytes long. The element \'{_name}\' is {unpaddedName.Length} bytes long and exceeds the limit by {unpaddedName.Length - _C_BNAME_MAX_LENGTH}.");
             }
+
             for (int i = 0; i < unpaddedName.Length && i < _C_BNAME_MAX_LENGTH; i++)
             {
                 bytes[i] = unpaddedName[i];
             }
+
             return bytes;
+        }
+
+        public uint Size()
+        {
+            return 81u;
         }
     }
 }


### PR DESCRIPTION
The library now depends on the nuget package instead of the submodule.
All appropriate refactors have been applied.
The submodule has been removed.

Resolves #1 
